### PR TITLE
Session history

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(PROJECT_SOURCES
     src/documentoutlinemodel.cpp
     src/documentstyle.cpp
     src/favouritecollection.cpp
+    src/globalhistory.cpp
     src/identitycollection.cpp
     src/ioutil.cpp
     src/localization.cpp

--- a/src/browsertab.cpp
+++ b/src/browsertab.cpp
@@ -862,6 +862,8 @@ void BrowserTab::updatePageTitle()
     page_title.replace(NL_REGEX, "");
     page_title = page_title.trimmed();
 
+    kristall::globals().history.setTitleForUrl(this->current_location, this->page_title);
+
     emit this->titleChanged(this->page_title);
 }
 
@@ -978,6 +980,7 @@ void BrowserTab::on_redirected(QUrl uri, bool is_permanent)
             this->current_location = uri;
             this->setUrlBarText(uri.toString(QUrl::FullyEncoded));
             this->history.replaceUrl(this->current_history_index.row(), uri);
+            kristall::globals().history.addVisit(uri);
         }
         else
         {
@@ -999,6 +1002,7 @@ void BrowserTab::setErrorMessage(const QString &msg)
 void BrowserTab::pushToHistory(const QUrl &url)
 {
     this->current_history_index = this->history.pushUrl(this->current_history_index, url);
+    kristall::globals().history.addVisit(url);
     this->updateUI();
 }
 

--- a/src/globalhistory.cpp
+++ b/src/globalhistory.cpp
@@ -1,0 +1,83 @@
+#include "globalhistory.hpp"
+
+GlobalHistory::GlobalHistory(QObject * parent)
+    : QAbstractListModel(parent)
+{
+
+}
+
+void GlobalHistory::addVisit(const QUrl &url)
+{
+    if(not url.isValid())
+        return;
+
+    if(not this->entries.isEmpty() and this->entries.first().url == url)
+        return;
+
+    this->beginInsertRows(QModelIndex{}, 0, 0);
+    this->entries.prepend(Entry {
+        url,
+        QString { },
+        QDateTime::currentDateTime(),
+    });
+    this->endInsertRows();
+}
+
+void GlobalHistory::setTitleForUrl(const QUrl &url, const QString &title)
+{
+    for(int i = 0; i < this->entries.size(); i++)
+    {
+        if(this->entries.at(i).url == url) {
+            this->entries[i].title = title;
+            emit this->dataChanged(this->index(i), this->index(i));
+            return;
+        }
+    }
+}
+
+QUrl GlobalHistory::get(const QModelIndex &index) const
+{
+    if(not index.isValid())
+        return QUrl { };
+
+    if(index.row() >= this->entries.size())
+        return QUrl { };
+
+    return this->entries.at(index.row()).url;
+}
+
+void GlobalHistory::clear()
+{
+    this->beginResetModel();
+    this->entries.clear();
+    this->endResetModel();
+}
+
+int GlobalHistory::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+    return this->entries.size();
+}
+
+QVariant GlobalHistory::data(const QModelIndex &index, int role) const
+{
+    if(not index.isValid() or index.row() >= this->entries.size())
+        return QVariant { };
+
+    auto const & entry = this->entries.at(index.row());
+
+    switch(role)
+    {
+    case Qt::DisplayRole:
+        return entry.url.toString();
+
+    case Qt::ToolTipRole:
+        if(entry.title.isEmpty())
+            return entry.visit_time.toString(Qt::TextDate);
+        else
+            return QString("%1\n%2").arg(entry.title, entry.visit_time.toString(Qt::TextDate));
+
+    default:
+        return QVariant { };
+    }
+}

--- a/src/globalhistory.hpp
+++ b/src/globalhistory.hpp
@@ -1,0 +1,43 @@
+#ifndef GLOBALHISTORY_HPP
+#define GLOBALHISTORY_HPP
+
+#include <QAbstractListModel>
+#include <QVector>
+#include <QUrl>
+#include <QString>
+#include <QDateTime>
+
+//! Session-wide list of visited urls, shared between all tabs and windows.
+//! In-memory only, newest visit first.
+class GlobalHistory : public QAbstractListModel
+{
+    Q_OBJECT
+
+    struct Entry
+    {
+        QUrl url;
+        QString title;
+        QDateTime visit_time;
+    };
+
+public:
+    explicit GlobalHistory(QObject * parent = nullptr);
+
+    void addVisit(QUrl const & url);
+
+    void setTitleForUrl(QUrl const & url, QString const & title);
+
+    QUrl get(QModelIndex const & index) const;
+
+    void clear();
+
+public:
+    int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+
+private:
+    QVector<Entry> entries;
+};
+
+#endif // GLOBALHISTORY_HPP

--- a/src/kristall.hpp
+++ b/src/kristall.hpp
@@ -9,6 +9,7 @@
 #include "identitycollection.hpp"
 #include "ssltrust.hpp"
 #include "favouritecollection.hpp"
+#include "globalhistory.hpp"
 #include "protocolsetup.hpp"
 #include "documentstyle.hpp"
 #include "cachehandler.hpp"
@@ -174,6 +175,7 @@ namespace kristall
         IdentityCollection identities;
         QClipboard * clipboard;
         FavouriteCollection favourites;
+        GlobalHistory history;
         GenericSettings options;
 
         DocumentStyle document_style;

--- a/src/kristall.pro
+++ b/src/kristall.pro
@@ -123,6 +123,7 @@ SOURCES += \
     documentoutlinemodel.cpp \
     documentstyle.cpp \
     favouritecollection.cpp \
+    globalhistory.cpp \
     identitycollection.cpp \
     ioutil.cpp \
     localization.cpp \
@@ -175,6 +176,7 @@ HEADERS += \
     documentoutlinemodel.hpp \
     documentstyle.hpp \
     favouritecollection.hpp \
+    globalhistory.hpp \
     identitycollection.hpp \
     ioutil.hpp \
     kristall.hpp \

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -48,9 +48,11 @@ MainWindow::MainWindow(QApplication * app, QWidget *parent) :
     this->statusBar()->addPermanentWidget(this->load_time);
 
     ui->favourites_view->setModel(&kristall::globals().favourites);
+    ui->session_history_view->setModel(&kristall::globals().history);
 
     this->ui->outline_window->setVisible(false);
     this->ui->history_window->setVisible(false);
+    this->ui->session_history_window->setVisible(false);
     this->ui->bookmarks_window->setVisible(false);
 
     for(QDockWidget * dock : findChildren<QDockWidget *>())
@@ -129,6 +131,7 @@ MainWindow::MainWindow(QApplication * app, QWidget *parent) :
 
     this->ui->favourites_view->setContextMenuPolicy(Qt::CustomContextMenu);
     this->ui->history_view->setContextMenuPolicy(Qt::CustomContextMenu);
+    this->ui->session_history_view->setContextMenuPolicy(Qt::CustomContextMenu);
 
     connect(this->ui->browser_tabs->tab_bar, &BrowserTabBar::on_newTabClicked, this, [this]() {
         this->addEmptyTab(true, true);
@@ -705,6 +708,33 @@ void MainWindow::on_history_view_customContextMenuRequested(const QPoint pos)
     }
 }
 
+void MainWindow::on_session_history_view_customContextMenuRequested(const QPoint pos)
+{
+    QMenu menu;
+
+    auto idx = this->ui->session_history_view->indexAt(pos);
+    if(QUrl url = kristall::globals().history.get(idx); url.isValid()) {
+        connect(menu.addAction(tr("Open here")), &QAction::triggered, [this, url]() {
+            BrowserTab * tab = this->curTab();
+            if(tab != nullptr) {
+                tab->navigateTo(url, BrowserTab::PushImmediate);
+            }
+        });
+
+        connect(menu.addAction(tr("Open in new tab")), &QAction::triggered, [this, url]() {
+            addNewTab(true, url);
+        });
+
+        menu.addSeparator();
+    }
+
+    connect(menu.addAction(tr("Clear history")), &QAction::triggered, []() {
+        kristall::globals().history.clear();
+    });
+
+    menu.exec(this->ui->session_history_view->mapToGlobal(pos));
+}
+
 void MainWindow::on_favourites_view_customContextMenuRequested(const QPoint pos)
 {
     if(auto idx = this->ui->favourites_view->indexAt(pos); idx.isValid()) {
@@ -850,6 +880,16 @@ void MainWindow::on_history_view_activated(const QModelIndex &index)
     BrowserTab * tab = this->curTab();
     if(tab != nullptr) {
         tab->navigateBack(index);
+    }
+}
+
+void MainWindow::on_session_history_view_activated(const QModelIndex &index)
+{
+    if(QUrl url = kristall::globals().history.get(index); url.isValid()) {
+        BrowserTab * tab = this->curTab();
+        if(tab != nullptr) {
+            tab->navigateTo(url, BrowserTab::PushImmediate);
+        }
     }
 }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -101,6 +101,8 @@ private slots:
 
     void on_history_view_customContextMenuRequested(const QPoint pos);
 
+    void on_session_history_view_customContextMenuRequested(const QPoint pos);
+
     void on_favourites_view_customContextMenuRequested(const QPoint pos);
 
     void on_actionChangelog_triggered();
@@ -116,6 +118,8 @@ private slots:
     void on_favourites_view_activated(const QModelIndex &index);
 
     void on_history_view_activated(const QModelIndex &index);
+
+    void on_session_history_view_activated(const QModelIndex &index);
 
     void on_outline_view_activated(const QModelIndex &index);
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -147,7 +147,7 @@
      <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="windowTitle">
-    <string>&amp;History</string>
+    <string>&amp;Tab History</string>
    </property>
    <property name="_shortcut" stdset="0">
     <string>Ctrl+H</string>
@@ -171,6 +171,40 @@
      </property>
      <item>
       <widget class="QListView" name="history_view"/>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="session_history_window">
+   <property name="windowIcon">
+    <iconset theme="history">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="windowTitle">
+    <string>&amp;Session History</string>
+   </property>
+   <property name="_shortcut" stdset="0">
+    <string>Ctrl+Shift+H</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_4">
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QListView" name="session_history_view"/>
      </item>
     </layout>
    </widget>


### PR DESCRIPTION
Current history only handles per-tab history and seems to be just a copy of navigation log, so here is a lousy implementation based off Favourites widget.

Nothing is saved to disk, I'm afraid it might cause speed issues with everything getting dumped to global INI. As far as I'm concerned it is now possible to track navigation history in browser and get back to that blog post tab you've just closed :)